### PR TITLE
Source environment from build.env

### DIFF
--- a/WPS/run_compile
+++ b/WPS/run_compile
@@ -14,14 +14,16 @@
 # 3. distributed memory code
 # 4. distributed memory code without GRIB2
 
-module purge
-module load pbs
-module load dot
-module load intel-fc/15.0.3.187
-module load intel-cc/15.0.3.187
-module load openmpi/1.8.8
-module load netcdf/4.3.3.1
-module load ncl/6.3.0
+source ../build.env
+
+#module purge
+#module load pbs
+#module load dot
+#module load intel-fc/15.0.3.187
+#module load intel-cc/15.0.3.187
+#module load openmpi/1.8.8
+#module load netcdf/4.3.3.1
+#module load ncl/6.3.0
 
 # Option to change HERE!
 ./configure << EOF_configure

--- a/WRFV3/run_compile
+++ b/WRFV3/run_compile
@@ -46,22 +46,23 @@
 
 compile_case=em_real
 
-module purge
-module load pbs
-module load dot
-module load intel-fc/17.0.1.132
-module load intel-cc/17.0.1.132
-module load openmpi/1.10.2
-module load openmp
-module load netcdf/4.3.3.1
-export WRFIO_NCD_LARGE_FILE_SUPPORT=1
+source ../build.env
+#module purge
+#module load pbs
+#module load dot
+#module load intel-fc/17.0.1.132
+#module load intel-cc/17.0.1.132
+#module load openmpi/1.10.2
+#module load openmp
+#module load netcdf/4.3.3.1
+#export WRFIO_NCD_LARGE_FILE_SUPPORT=1
 
 # Un-comment to compile with chemistry
 #export WRF_CHEM=1
 
 # !!!! CONFIGURE OPTIONS HERE !!!!
 ./configure << EOF_configure
-3
+4
 1
 EOF_configure
 

--- a/build.env
+++ b/build.env
@@ -1,0 +1,15 @@
+module purge
+module load pbs
+module load dot
+module load intel-fc/17.0.1.132
+module load intel-cc/17.0.1.132
+module load openmpi/1.10.2
+module load ncl/6.3.0
+module load netcdf/4.3.3.1
+export WRFIO_NCD_LARGE_FILE_SUPPORT=1
+
+#Uncomment if compiling with WRF_CHEM
+#export WRF_CHEM=1
+
+#Uncomment if writing outputs in netcdf4 with compression
+#export NETCDF4=1


### PR DESCRIPTION
To avoid changing environment options everywhere, source from build.env in the compilation
scripts.

Signed-off-by: C. Carouge <c.carouge@unsw.edu.au>