### PR TITLE
Fixes #2 Bad definition of ndt dimension

### DIFF
--- a/WRF/Registry/registry.dimspec
+++ b/WRF/Registry/registry.dimspec
@@ -32,7 +32,7 @@ dimspec    obsstid -     constant=40                       c     obs station id 
 dimspec    &       2     namelist=lagday                   z     lagday
 dimspec    seed    1     namelist=seed_dim                 z     seed_dim
 # ccc Add dimensions for window averaging.
-dimspec    ndt     4     namelist=max_window               2     Window max size
+dimspec    ndt     4     namelist=max_window               z     Window max size
 # ccc
 endif
 


### PR DESCRIPTION
A dimension type "2" does not exist for WRF. Fixed the typo to "z".